### PR TITLE
proportional chat length

### DIFF
--- a/web/dart/chat_bubble.dart
+++ b/web/dart/chat_bubble.dart
@@ -10,8 +10,8 @@ class ChatBubble
   ChatBubble(this.text)
   {
     timeToLive = text.length * 0.1 + 3; //minimum 3s plus 0.1s per character
-    if (timeToLive > 15) {
-      timeToLive = 15;
+    if (timeToLive > 15) { //max 15s
+      timeToLive = 15; //messages over 15s will only display for 15s
     }
     bubble = new DivElement()
       ..classes.add("PlayerChatBubble");


### PR DESCRIPTION
Makes longer messages stay in a bubble longer than shorter messages.
